### PR TITLE
Collapsed Property to hide the palette initially

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ You can also use the minified sources directly:
 | variant      | String  | `collapsible` | Use `persistent` to prevent collapsing/closing |
 | mouse-scroll | Boolean | `false`       | Use wheel (scroll) event to rotate. |
 | step         | Number  | `2`           | Amount of degrees to rotate the picker with keyboard and/or wheel. |
+| collapsed    | Boolean | `false`       | Hides the palette initially |
 
 ### Events
 

--- a/src/ColorPicker.vue
+++ b/src/ColorPicker.vue
@@ -60,11 +60,14 @@
             disabled: {
                 default: false,
             },
+            collapsed: {
+                default: false
+            }
         },
         data() {
             return {
-                isPaletteIn: true,
-                isKnobIn: true,
+                isPaletteIn: !this.collapsed,
+                isKnobIn: !this.collapsed,
                 isPressed: false,
                 isRippling: false,
                 isDragging: false,

--- a/src/ColorPicker.vue
+++ b/src/ColorPicker.vue
@@ -77,6 +77,9 @@
             color() {
                 return `hsla(${this.hue}, ${this.saturation}%, ${this.luminosity}%, ${this.alpha})`;
             },
+            propertiesAreConflicting() {
+                return this.initiallyCollapsed && this.variant === "persistent"
+            }
         },
         watch: {
             hue: function(angle) {
@@ -86,6 +89,10 @@
         mounted() {
             if (this.mouseScroll) {
                 this.$refs.rotator.addEventListener('wheel', this.onScroll);
+            }
+
+            if (this.propertiesAreConflicting) {
+                console.warn(`Incorrect config: using variant="persistent" and :initiallyCollapsed="true" at the same time is not supported.`)
             }
 
             const isConicGradientSupported = getComputedStyle(this.$refs.palette)

--- a/src/ColorPicker.vue
+++ b/src/ColorPicker.vue
@@ -60,14 +60,14 @@
             disabled: {
                 default: false,
             },
-            collapsed: {
+            initiallyCollapsed: {
                 default: false
             }
         },
         data() {
             return {
-                isPaletteIn: !this.collapsed,
-                isKnobIn: !this.collapsed,
+                isPaletteIn: !this.initiallyCollapsed,
+                isKnobIn: !this.initiallyCollapsed,
                 isPressed: false,
                 isRippling: false,
                 isDragging: false,

--- a/src/ColorPicker.vue
+++ b/src/ColorPicker.vue
@@ -76,13 +76,10 @@
         computed: {
             color() {
                 return `hsla(${this.hue}, ${this.saturation}%, ${this.luminosity}%, ${this.alpha})`;
-            },
-            propertiesAreConflicting() {
-                return this.initiallyCollapsed && this.variant === "persistent"
             }
         },
         watch: {
-            hue: function(angle) {
+            hue: function (angle) {
                 this.rcp.angle = angle;
             },
         },
@@ -91,7 +88,7 @@
                 this.$refs.rotator.addEventListener('wheel', this.onScroll);
             }
 
-            if (this.propertiesAreConflicting) {
+            if (this.hasConflictingProperties()) {
                 console.warn(`Incorrect config: using variant="persistent" and :initiallyCollapsed="true" at the same time is not supported.`)
             }
 
@@ -117,6 +114,9 @@
             });
         },
         methods: {
+            hasConflictingProperties() {
+                return this.initiallyCollapsed && this.variant === "persistent"
+            },
             onScroll(ev) {
                 if (this.isPressed || !this.isKnobIn)
                     return;
@@ -244,7 +244,7 @@
         overflow: hidden;
         will-change: transform, opacity;
         transition: transform .5s cubic-bezier(0.35, 0, 0.25, 1),
-                    opacity .5s cubic-bezier(0.35, 0, 0.25, 1);
+        opacity .5s cubic-bezier(0.35, 0, 0.25, 1);
     }
 
     .rcp__palette::before {
@@ -325,7 +325,7 @@
     }
 
     .rcp__well::-moz-focus-inner {
-      border: 0;
+        border: 0;
     }
 
     .rcp__well:hover {
@@ -363,8 +363,13 @@
     }
 
     @keyframes rcp-ripple {
-        0%   { transform: scale(1); opacity: .3; }
-        50%  { opacity: .1; }
+        0% {
+            transform: scale(1);
+            opacity: .3;
+        }
+        50% {
+            opacity: .1;
+        }
         100% {
             opacity: 0;
             border-width: 0;
@@ -373,9 +378,17 @@
     }
 
     @keyframes rcp-beat {
-        0%   { transform: scale(1); }
-        25%  { transform: scale(0.8); }
-        50%  { transform: scale(1); }
-        100% { transform: scale(1); }
+        0% {
+            transform: scale(1);
+        }
+        25% {
+            transform: scale(0.8);
+        }
+        50% {
+            transform: scale(1);
+        }
+        100% {
+            transform: scale(1);
+        }
     }
 </style>

--- a/tests/unit/__snapshots__/index.spec.js.snap
+++ b/tests/unit/__snapshots__/index.spec.js.snap
@@ -13,7 +13,7 @@ exports[`Init renders correctly 1`] = `
    
   <div
     class="rcp__rotator"
-    style="transform: rotate(0deg);"
+    style="will-change: transform; transform: rotate(0deg);"
   >
     <div
       class="rcp__knob in"
@@ -22,10 +22,12 @@ exports[`Init renders correctly 1`] = `
    
   <div
     class="rcp__ripple"
+    style="border-color: hsla(0, 100%, 50%, 1);"
   />
    
   <button
     class="rcp__well"
+    style="background-color: hsl(0, 100%, 50%);"
     type="button"
   />
 </div>

--- a/tests/unit/index.spec.js
+++ b/tests/unit/index.spec.js
@@ -1,8 +1,8 @@
-import { shallowMount } from '@vue/test-utils';
+import {shallowMount} from '@vue/test-utils';
 import ColorPicker from '@/src/ColorPicker.vue';
-
 // canvas support in JSDom is weak and throws an error so the dependency is mocked
 import fillColorWheel from '@radial-color-picker/color-wheel';
+
 jest.mock('@radial-color-picker/color-wheel');
 
 describe('Init', () => {
@@ -78,6 +78,28 @@ describe('Core Methods', () => {
         el.vm.selectColor();
 
         expect(el.emitted('change')[0]).toEqual([30]);
+    });
+
+    it('has conflicting properties if collapsed is set to true and variant is set to persistent', () => {
+        const el = shallowMount(ColorPicker, {
+            propsData: {
+                initiallyCollapsed: true,
+                variant: 'persistent'
+            }
+        });
+
+        expect(el.vm.hasConflictingProperties()).toEqual(true);
+    });
+
+    it('has no conlicts if collapsed is set to true and variant is set to collapsible', () => {
+        const el = shallowMount(ColorPicker, {
+            propsData: {
+                initiallyCollapsed: true,
+                variant: 'collapsible'
+            }
+        });
+
+        expect(el.vm.hasConflictingProperties()).toEqual(false);
     });
 
     it('shows the palette when selectColor is called and the picker is closed', () => {
@@ -456,7 +478,7 @@ describe('Reactive Changes', () => {
             },
         });
 
-        el.setProps({ hue: 60 });
+        el.setProps({hue: 60});
 
         expect(el.vm.rcp.angle).toBe(60);
     });
@@ -471,7 +493,7 @@ describe('Reactive Changes', () => {
             },
         });
 
-        el.setProps({ hue: 60 });
+        el.setProps({hue: 60});
 
         expect(el.vm.hue).toBe(60);
         expect(el.vm.saturation).toBe(100);


### PR DESCRIPTION
I've added a collapsed property to initially hide the palette. This is needed in my use-case because it's rendered inside of a v-card.